### PR TITLE
[WFLY-17156] Fix the Bootable JAR TCK execution

### DIFF
--- a/testsuite/integration/microprofile-tck/telemetry/src/test/resources/arquillian-bootable.xml
+++ b/testsuite/integration/microprofile-tck/telemetry/src/test/resources/arquillian-bootable.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<arquillian xmlns="http://jboss.org/schema/arquillian" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+    <defaultProtocol type="jmx-as7" />
+
+    <container qualifier="jboss" default="true">
+        <configuration>
+            <property name="installDir">${install.dir}</property>
+            <property name="jarFile">${bootable.jar}</property>
+
+            <property name="javaVmArguments">${microprofile.jvm.args}</property>
+            <property name="managementAddress">127.0.0.1</property>
+            <property name="managementPort">9990</property>
+            <property name="allowConnectingToRunningServer">true</property>
+            <property name="waitForPorts">9990</property>
+            <property name="waitForPortsTimeoutInSeconds">10</property>
+        </configuration>
+    </container>
+
+</arquillian>


### PR DESCRIPTION
This is to fix the [MicroProfile Telemetry TCKs execution](https://ci.wildfly.org/buildConfiguration/WF_PullRequest_BootableJarLinuxJdk11/359284?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildChangesSection=true&expandBuildTestsSection=true) in the [WildFly MP Telemetry integration PR](https://github.com/wildfly/wildfly/pull/16330).